### PR TITLE
Add go v1.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 
 go:
   - "1.11"
+  - "1.12"
+  - "1.13"
   - master
 
 addons:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/seqsense/sq-gst-go
 
-go 1.12
+go 1.13


### PR DESCRIPTION
- Add golang version `"1.12"` and `"1.13"` support to `.travis.yaml`
- Update `go.mod` golang version to `1.13`