### PR TITLE
Fix improper GObjectClass initialization in Element.GetProperty

### DIFF
--- a/element.go
+++ b/element.go
@@ -45,9 +45,8 @@ package gst
 // GValue* getProperty(void* element, const char* name)
 // {
 //   g_object_ref(element);
-//   GObjectClass klass;
-//   klass.g_type_class.g_type = G_OBJECT_TYPE(element);
-//   GParamSpec* pspec = g_object_class_find_property(&klass, name);
+//   GObjectClass *klass = G_OBJECT_GET_CLASS(element);
+//   GParamSpec* pspec = g_object_class_find_property(klass, name);
 //   if (pspec == NULL)
 //   {
 //     g_object_unref(element);

--- a/element.go
+++ b/element.go
@@ -45,8 +45,7 @@ package gst
 // GValue* getProperty(void* element, const char* name)
 // {
 //   g_object_ref(element);
-//   GObjectClass *klass = G_OBJECT_GET_CLASS(element);
-//   GParamSpec* pspec = g_object_class_find_property(klass, name);
+//   GParamSpec* pspec = g_object_class_find_property(G_OBJECT_GET_CLASS(element), name);
 //   if (pspec == NULL)
 //   {
 //     g_object_unref(element);


### PR DESCRIPTION
Official example: https://github.com/GNOME/glib/blob/537a33a49f95885668fc85824acfe93bd1962308/gobject/tests/properties.c#L251