### PR TITLE
Migrate deprecated g_memdup to g_memdup2

### DIFF
--- a/appsrc/appsrc.c
+++ b/appsrc/appsrc.c
@@ -23,8 +23,12 @@
 
 void pushBuffer(void* element, void* buffer, int len)
 {
-  GstBuffer* buffer_gst =
-      gst_buffer_new_wrapped(g_memdup2(buffer, len), len);
+#if GLIB_CHECK_VERSION(2, 68, 0)
+  gpointer mem = g_memdup2(buffer, len);
+#else
+  gpointer mem = g_memdup(buffer, len);
+#endif
+  GstBuffer* buffer_gst = gst_buffer_new_wrapped(mem, len);
   gst_app_src_push_buffer(GST_APP_SRC(element), buffer_gst);
 }
 

--- a/appsrc/appsrc.c
+++ b/appsrc/appsrc.c
@@ -24,7 +24,7 @@
 void pushBuffer(void* element, void* buffer, int len)
 {
   GstBuffer* buffer_gst =
-      gst_buffer_new_wrapped(g_memdup(buffer, len), len);
+      gst_buffer_new_wrapped(g_memdup2(buffer, len), len);
   gst_app_src_push_buffer(GST_APP_SRC(element), buffer_gst);
 }
 


### PR DESCRIPTION
Fix following warning:
```
# github.com/seqsense/sq-gst-go/appsrc
appsrc.c: In function ‘pushBuffer’:
appsrc.c:27:7: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
   27 |       gst_buffer_new_wrapped(g_memdup(buffer, len), len);
      |       ^~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib/gstring.h:37,
                 from /usr/include/glib-2.0/glib/giochannel.h:36,
                 from /usr/include/glib-2.0/glib.h:56,
                 from /usr/include/gstreamer-1.0/gst/gst.h:27,
                 from appsrc.c:21:
/usr/include/glib-2.0/glib/gstrfuncs.h:350:23: note: declared here
  350 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
```